### PR TITLE
Restore "mute" message

### DIFF
--- a/slstatus.c
+++ b/slstatus.c
@@ -472,6 +472,7 @@ uid(void)
 static char *
 vol_perc(const char *card)
 {
+	int mute;
 	long int vol, max, min;
 	snd_mixer_t *handle;
 	snd_mixer_elem_t *elem;
@@ -495,11 +496,14 @@ vol_perc(const char *card)
 	snd_mixer_handle_events(handle);
 	snd_mixer_selem_get_playback_volume_range(elem, &min, &max);
 	snd_mixer_selem_get_playback_volume(elem, 0, &vol);
+	snd_mixer_selem_get_playback_switch(elem, 0, &mute);
 
 	snd_mixer_selem_id_free(s_elem);
 	snd_mixer_close(handle);
 
-	if (max == 0)
+	if (!mute)
+		return smprintf("mute");
+	else if (max == 0)
 		return smprintf("0%%");
 	else
 		return smprintf("%lu%%", ((uint_fast16_t)(vol * 100) / max));


### PR DESCRIPTION
This feature was originally removed as part of commit 52d19f9.  Was this on purpose?  It seems like a pretty nice thing to have in the `vol_perc` function, and so I added it again here.