### PR TITLE
Add a "uname -r" feature to see which kernel is running

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@ Thanks you very much for your great help!
 - [sahne](https://github.com/sahne)
 - [Ali H. Fardan](http://raiz.duckdns.org)
 - [Quentin Rameau](https://fifth.space)
+- [Mike Coddington](https://coddington.us)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The following information is included:
 - Username/GID/UID
 - Hostname
 - IP addresses
+- Kernel version
 - Load averages
 - Memory status (free memory, percentage, total memory and used memory)
 - Swap status (free swap, percentage, total swap and used swap)

--- a/config.def.h
+++ b/config.def.h
@@ -19,6 +19,7 @@
 - gid (gid of current user) [argument: NULL]
 - hostname [argument: NULL]
 - ip (ip address) [argument: interface]
+- kernel_release (uname -r) [argument: NULL]
 - load_avg (load average) [argument: NULL]
 - ram_free (free ram in GB) [argument: NULL]
 - ram_perc (ram usage in percent) [argument: NULL]

--- a/slstatus.c
+++ b/slstatus.c
@@ -20,6 +20,7 @@
 #include <sys/socket.h>
 #include <sys/sysinfo.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <time.h>
 #include <unistd.h>
 #include <X11/Xlib.h>
@@ -68,6 +69,7 @@ static char *username(void);
 static char *vol_perc(const char *card);
 static char *wifi_perc(const char *iface);
 static char *wifi_essid(const char *iface);
+static char *kernel_release(void);
 static void set_status(const char *str);
 static void sighandler(const int signo);
 static void usage(void);
@@ -719,6 +721,16 @@ wifi_essid(const char *iface)
 		return smprintf(UNKNOWN_STR);
 	else
 		return smprintf("%s", (char *)wreq.u.essid.pointer);
+}
+
+static char *
+kernel_release(void)
+{
+	struct utsname udata;
+	if (uname(&udata) < 0)
+		return smprintf(UNKNOWN_STR);
+
+	return smprintf("%s", udata.release);
 }
 
 static void


### PR DESCRIPTION
This only works in Linux. I'm not sure how to implement such a feature in BSD, so if graceful BSD compiling is a requirement, feel free and reject this pull request.