### PR TITLE
On success, fgets always terminates the result.

### DIFF
--- a/slstatus.c
+++ b/slstatus.c
@@ -447,7 +447,7 @@ run_command(const char *cmd)
 		warn("Failed to get command output for %s", cmd);
 		return smprintf("%s", UNKNOWN_STR);
 	}
-	fgets(buf, sizeof(buf) - 1, fp);
+	fgets(buf, sizeof(buf), fp);
 	pclose(fp);
 	buf[sizeof(buf) - 1] = '\0';
 


### PR DESCRIPTION
If fgets succeeds, then the resulting char array is always
terminated by a '\0'. No need to keep extra space, therefore
sizeof(buf) is the correct argument.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>