### PR TITLE
keyboard_indicators: fix segfault when -s is specified

### DIFF
--- a/slstatus.c
+++ b/slstatus.c
@@ -380,9 +380,15 @@ kernel_release(void)
 static const char *
 keyboard_indicators(void)
 {
+	Display *dpy = XOpenDisplay(NULL);
 	XKeyboardState state;
 
+	if (dpy == NULL) {
+		warnx("XOpenDisplay failed");
+		return UNKNOWN_STR;
+	}
 	XGetKeyboardControl(dpy, &state);
+	XCloseDisplay(dpy);
 
 	switch (state.led_mask) {
 		case 1:


### PR DESCRIPTION
tl;dr

```
[raiz@localhost slstatus]$ make
cc -o slstatus -std=c99 -pedantic -Wall -Wextra -Wno-unused -Os -I/usr/X11R6/include -D_DEFAULT_SOURCE -L/usr/X11R6/lib -s slstatus.c -lX11
[raiz@localhost slstatus]$ ./slstatus -s
Segmentation fault
[raiz@localhost slstatus]$
```

`config.h`:
```
#define UPDATE_INTERVAL 1
#define UNKNOWN_STR "n/a"
#define MAXLEN 2048

static const struct arg args[] = {
        { keyboard_indicators, "%s", NULL },
};
```