### PR TITLE
Allow generic network interface names

### DIFF
--- a/components/ip.c
+++ b/components/ip.c
@@ -24,7 +24,7 @@ ipv4(const char *iface)
 			continue;
 		}
 		s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
-		if ((strcmp(ifa->ifa_name, iface) == 0) && (ifa->ifa_addr->sa_family == AF_INET)) {
+		if ((strncmp(ifa->ifa_name, iface, strlen(iface)) == 0) && (ifa->ifa_addr->sa_family == AF_INET)) {
 			if (s != 0) {
 				warnx("Failed to get IPv4 address for interface %s", iface);
 				return NULL;
@@ -55,7 +55,7 @@ ipv6(const char *iface)
 			continue;
 		}
 		s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in6), host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
-		if ((strcmp(ifa->ifa_name, iface) == 0) && (ifa->ifa_addr->sa_family == AF_INET6)) {
+		if ((strncmp(ifa->ifa_name, iface, strlen(iface)) == 0) && (ifa->ifa_addr->sa_family == AF_INET6)) {
 			if (s != 0) {
 				warnx("Failed to get IPv6 address for interface %s", iface);
 				return NULL;


### PR DESCRIPTION
This allows one to use only the generic part of an interface name without its unique identifier, such as `wlp` or `enp`. There is usually one network interface per type only, so you don't end up to change your config on every machine. 

```
static const struct arg args[] = {
	{ ipv4, "%s | ", "wlp" },
	{ battery_perc, "BAT %s%% | ", "BAT0" },
	{ battery_power, "%s W | ", "BAT0" },
	{ datetime, "%s", "%F %T" },
};
```