### PR TITLE
Print unknown_str in case of error

### DIFF
--- a/slstatus.c
+++ b/slstatus.c
@@ -87,8 +87,10 @@ main(int argc, char *argv[])
 
 		status[0] = '\0';
 		for (i = len = 0; i < LEN(args); i++) {
+			const char * res = args[i].func(args[i].args);
+			res = (res == NULL) ? unknown_str : res;
 			len += snprintf(status + len, sizeof(status) - len,
-			                args[i].fmt, args[i].func(args[i].args));
+			                args[i].fmt, res);
 
 			if (len >= sizeof(status)) {
 				status[sizeof(status) - 1] = '\0';


### PR DESCRIPTION
func can return NULL, but no checking is done when printing, and `unknown_str` wasn't being used anywhere.
Instead of checking for NULL after every function call, the functions could return `unknown_str` themselves. They don't have access to `unknown_str` right now though.