### PR TITLE
Add OpenBSD RAM stats

### DIFF
--- a/components/ram.c
+++ b/components/ram.c
@@ -1,9 +1,9 @@
 /* See LICENSE file for copyright and license details. */
-#if defined(__linux__)
 #include <stdio.h>
 
 #include "../util.h"
 
+#if defined(__linux__)
 const char *
 ram_free(void)
 {
@@ -50,5 +50,79 @@ ram_used(void)
 	               &total, &free, &buffers, &buffers, &cached) == 5) ?
 	       bprintf("%f", (float)(total - free - buffers - cached) / 1024 / 1024) :
 	       NULL;
+}
+#elif defined(__OpenBSD__)
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+inline int
+load_uvmexp(struct uvmexp *uvmexp)
+{
+	int uvmexp_mib[] = {CTL_VM, VM_UVMEXP};
+	size_t size;
+
+	size = sizeof(*uvmexp);
+
+	return sysctl(uvmexp_mib, 2, uvmexp, &size, NULL, 0) >= 0 ? 1 : 0;
+}
+
+const char *
+ram_free(void)
+{
+	struct uvmexp uvmexp;
+	float free;
+	int free_pages;
+
+	if (load_uvmexp(&uvmexp)) {
+		free_pages = uvmexp.npages - uvmexp.active;
+		free = (double) (free_pages * uvmexp.pagesize) / 1024 / 1024 / 1024;
+		return bprintf("%f", free);
+	}
+
+	return NULL;
+}
+
+const char *
+ram_perc(void)
+{
+	struct uvmexp uvmexp;
+	int percent;
+
+	if (load_uvmexp(&uvmexp)) {
+		percent = uvmexp.active * 100 / uvmexp.npages;
+		return bprintf("%d", percent);
+	}
+
+	return NULL;
+}
+
+const char *
+ram_total(void)
+{
+	struct uvmexp uvmexp;
+	float total;
+
+	if (load_uvmexp(&uvmexp)) {
+		total = (double) (uvmexp.npages * uvmexp.pagesize) / 1024 / 1024 / 1024;
+		return bprintf("%f", total);
+	}
+
+	return NULL;
+}
+
+const char *
+ram_used(void)
+{
+	struct uvmexp uvmexp;
+	float used;
+
+	if (load_uvmexp(&uvmexp)) {
+		used = (double) (uvmexp.active * uvmexp.pagesize) / 1024 / 1024 / 1024;
+		return bprintf("%f", used);
+	}
+
+	return NULL;
 }
 #endif


### PR DESCRIPTION
I've added OpenBSD versions of the ram_{free,perc,total,used} functions.